### PR TITLE
Fix for 'MalformedPolicyDocument: Syntax error at position'

### DIFF
--- a/data.aws_iam_policy_document.trust.tf
+++ b/data.aws_iam_policy_document.trust.tf
@@ -6,7 +6,7 @@ data "aws_iam_policy_document" "trust" {
     ]
 
     principals {
-      type        = "service"
+      type        = "Service"
       identifiers = ["dlm.amazonaws.com"]
     }
   }


### PR DESCRIPTION
Trying to use the module would fail with the folllowing.

Error: Error creating IAM Role dlm-lifecycle-role: MalformedPolicyDocument: Syntax error at position (9,21)
        status code: 400, request id: XXXXXXXXXXXXXXXX

  on .terraform/modules/datalifecycle.dlmautosnapshot/aws_iam_role.dlm_lifecycle.tf line 1, in resource "aws_iam_role" "dlm_lifecycle":
   1: resource "aws_iam_role" "dlm_lifecycle" {

The fix for me was as simple as switch 'service' to 'Service'